### PR TITLE
Add CVPR bibtex to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,18 @@ Currently supported tasks are:
 If you find our work interesting, please consider citing
 
 ```
+@inproceedings{zhang2025improvingdiffusioninverseproblem,
+  title = {Improving {{Diffusion Inverse Problem Solving}} with {{Decoupled Noise Annealing}}},
+  booktitle = {Proceedings of the {{IEEE}}/{{CVF}} Conference on Computer Vision and Pattern Recognition ({{CVPR}})},
+  author = {Zhang, Bingliang and Chu, Wenda and Berner, Julius and Meng, Chenlin and Anandkumar, Anima and Song, Yang},
+  year = 2025,
+  pages = {20895--20905}
+}
+```
+
+or
+
+```
 @misc{zhang2024improvingdiffusioninverseproblem,
       title={Improving Diffusion Inverse Problem Solving with Decoupled Noise Annealing}, 
       author={Bingliang Zhang and Wenda Chu and Julius Berner and Chenlin Meng and Anima Anandkumar and Yang Song},


### PR DESCRIPTION
Repo has `bibtex` of arXiv version, but proposing addition of CVPR bibtex for people wanting to cite the published version. Matched key format of original citation.

Note: original `bibtex`'s `title` field does not protect capitalization (e.g. `{Improving Diffusion Inverse Problem Solving with Decoupled Noise Annealing}` may read `Improving diffusion inverse problem solving with decoupled noise annealing` depending on compile settings). I added the caps protection to the CVPR entry, but left the original untouched. Can quickly add to both or neither if you'd like.